### PR TITLE
Remove protocol from go get url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the command specific help to guide your user.
 ### Install
 
 ```
-$ go get https://github.com/Yitsushi/go-commander
+$ go get github.com/Yitsushi/go-commander
 ```
 
 ### Sample output _(from [totp-cli](https://github.com/Yitsushi/totp-cli))_


### PR DESCRIPTION
Removing https from the `go get` command, to avoid the error: `package https:/github.com/Yitsushi/go-commander: "https://" not allowed in import path`.